### PR TITLE
Collect the flow with lifecycle aware, and upstream the flow only when there is a subscriber subscribed

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,6 +73,7 @@ dependencies {
     // AndroidX
     implementation("androidx.core:core-ktx:1.13.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.6.2")
     implementation("androidx.activity:activity-compose:1.9.0")
     implementation(platform("androidx.compose:compose-bom:2024.04.01"))
     implementation("androidx.compose.ui:ui")

--- a/app/src/main/java/com/example/playground/animalfacts/view/AnimalFactsFragment.kt
+++ b/app/src/main/java/com/example/playground/animalfacts/view/AnimalFactsFragment.kt
@@ -5,12 +5,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
@@ -43,7 +43,7 @@ class AnimalFactsFragment: Fragment() {
             .apply {
                 setContent {
                     PlaygroundTheme {
-                        val viewState by viewModel.animalFactsScreenViewStateFlow.collectAsState()
+                        val viewState by viewModel.animalFactsScreenViewStateFlow.collectAsStateWithLifecycle()
                         AnimalFactsScreen(viewState)
                     }
                 }

--- a/app/src/main/java/com/example/playground/animalfacts/viewmodel/AnimalFactsViewModel.kt
+++ b/app/src/main/java/com/example/playground/animalfacts/viewmodel/AnimalFactsViewModel.kt
@@ -20,12 +20,16 @@ class AnimalFactsViewModel @Inject constructor(
     private val animalDataProvider: AnimalDataProvider
 ) : ViewModel() {
 
+    companion object {
+        private const val DELAY_STOP_TIMEOUT_IN_MILLIS = 5000L
+    }
+
     private val _animalFactsScreenViewStateFlow: MutableStateFlow<AnimalFactsScreenViewState> =
         buildAnimalFactsScreenViewState()
     val animalFactsScreenViewStateFlow: StateFlow<AnimalFactsScreenViewState>
         get() = _animalFactsScreenViewStateFlow.stateIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
+            started = SharingStarted.WhileSubscribed(DELAY_STOP_TIMEOUT_IN_MILLIS),
             initialValue = _animalFactsScreenViewStateFlow.value,
         )
 

--- a/app/src/main/java/com/example/playground/animalfacts/viewmodel/AnimalFactsViewModel.kt
+++ b/app/src/main/java/com/example/playground/animalfacts/viewmodel/AnimalFactsViewModel.kt
@@ -9,7 +9,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -21,12 +23,15 @@ class AnimalFactsViewModel @Inject constructor(
     private val _animalFactsScreenViewStateFlow: MutableStateFlow<AnimalFactsScreenViewState> =
         buildAnimalFactsScreenViewState()
     val animalFactsScreenViewStateFlow: StateFlow<AnimalFactsScreenViewState>
-        get() = _animalFactsScreenViewStateFlow
+        get() = _animalFactsScreenViewStateFlow.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = _animalFactsScreenViewStateFlow.value,
+        )
 
     private val _navigateUpFlow: MutableSharedFlow<Unit> = MutableSharedFlow()
     val navigateUp: SharedFlow<Unit>
         get() = _navigateUpFlow
-
 
     private fun buildAnimalFactsScreenViewState() = MutableStateFlow(
         AnimalFactsScreenViewState(

--- a/app/src/main/java/com/example/playground/home/view/HomeFragment.kt
+++ b/app/src/main/java/com/example/playground/home/view/HomeFragment.kt
@@ -5,12 +5,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
@@ -43,7 +43,7 @@ class HomeFragment: Fragment() {
             .apply {
                 setContent {
                     PlaygroundTheme {
-                        val viewState by viewModel.homeScreenViewStateFlow.collectAsState()
+                        val viewState by viewModel.homeScreenViewStateFlow.collectAsStateWithLifecycle()
                         HomeScreen(viewState)
                     }
                 }
@@ -63,7 +63,6 @@ class HomeFragment: Fragment() {
                 }
             }
         }
-
     }
 }
 

--- a/app/src/main/java/com/example/playground/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/playground/home/viewmodel/HomeViewModel.kt
@@ -8,7 +8,9 @@ import com.example.playground.home.viewstate.HomeScreenViewState
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -22,7 +24,11 @@ class HomeViewModel @Inject constructor(
     private val _homeScreenViewStateFlow: MutableStateFlow<HomeScreenViewState> =
         buildHomeScreenViewState()
     val homeScreenViewStateFlow: StateFlow<HomeScreenViewState>
-        get() = _homeScreenViewStateFlow
+        get() = _homeScreenViewStateFlow.stateIn(
+            scope = viewModelScope,
+            started = WhileSubscribed(5000),
+            initialValue = _homeScreenViewStateFlow.value,
+        )
 
     private val _navigateToDestinationFlow: MutableSharedFlow<Int> = MutableSharedFlow()
     val navigateToDestinationFlow: SharedFlow<Int>

--- a/app/src/main/java/com/example/playground/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/playground/home/viewmodel/HomeViewModel.kt
@@ -21,12 +21,16 @@ class HomeViewModel @Inject constructor(
     private val application: Application,
 ) : ViewModel() {
 
+    companion object {
+        private const val DELAY_STOP_TIMEOUT_IN_MILLIS = 5000L
+    }
+
     private val _homeScreenViewStateFlow: MutableStateFlow<HomeScreenViewState> =
         buildHomeScreenViewState()
     val homeScreenViewStateFlow: StateFlow<HomeScreenViewState>
         get() = _homeScreenViewStateFlow.stateIn(
             scope = viewModelScope,
-            started = WhileSubscribed(5000),
+            started = WhileSubscribed(DELAY_STOP_TIMEOUT_IN_MILLIS),
             initialValue = _homeScreenViewStateFlow.value,
         )
 


### PR DESCRIPTION
- It's recommended to utilize 'collectAsStateWithLifecycle() API' rather than 'collectAsState() API' because of it's lifecycle awareness. When the app is minimized, it no longer collects(Unsubscribes) the data from flow. 

- In order to stop upstream of flow when no subscriber is attached, we could add .stateIn(WhileSubscribed(5000)). This stops the upstream of data in Flow after 5000 milliseconds when no subscriber is attached. This 5000 milli seconds is a grace time which will patch the device orientation change (Where view will be unsubscribed for less than 5000 milli seconds)